### PR TITLE
docs: add MySQL setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ If you are using [@nexus/schema](https://www.npmjs.com/package/@nexus/schema) yo
 If you are using Prisma's migrations you can simply run `prisma migrate save` and `prisma migrate up` to migrate your database.
 If you are using something other then `prisma` then you will need to manage the migrations yourself and you check the [Prisma Documentation](https://www.prisma.io/docs/getting-started/setup-prisma/start-from-scratch-sql-typescript-postgres#create-database-tables-with-sql) on the subject if you need help.
 
+#### MySQL
+
+If you are using MySQL as your datasource provider you may also need change the type of your data column to be TEXT:
+```sql
+USE your-database
+ALTER TABLE Session MODIFY data TEXT;
+```
+Prisma `String` properties are mapped to `VARCHAR(191)` by default. Session data can be larger than 191 characters so updating the type to `TEXT` prevents errors when creating and updating sessions. If you know your session data will not exceed 191 characters you can skip this step or if you know your maximum size you can use `VARCHAR(YOUR_MAX_SIZE)`
+
+If you are using a version of Prisma that supports [migrating with native types](https://github.com/prisma/prisma/issues/4330) you can use a type annotation in your `schema.prisma` file instead of manually modifying your data column.
+
 ## Migrating from versions prior to `1.0.0`
 
 In `1.0.0` the public API of this library was reworked. Previously the default export that was a


### PR DESCRIPTION
MySQL requires additional setup related to the maximum size of the data
column. Prisma uses a maximum character limit of 191 by default, this
can lead to errors creating and updating sessions. Suggest mysql users
use TEXT type to avoid hitting the character limit since session data
can be large.

Closes #21 