### PR TITLE
Add option for sessionModelName

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ If you are using a version of Prisma that supports [migrating with native types]
 
 Following version `2.0.0`, the `Session` `expires` field was renamed to `expiresAt` to match Prisma's naming convention for date fields.
 
-
 ## Migrating from versions prior to `1.0.0`
 
 In `1.0.0` the public API of this library was reworked. Previously the default export that was a
@@ -201,6 +200,8 @@ CUID will be used instead.
 - `noDisposeOnSet` By default, if you set a `dispose()` method, then it'll be called whenever a `set()` operation overwrites an existing key. If you set this option, `dispose()` will only be called when a key falls out of the cache, not when it is overwritten.
 
 - `serializer` An object containing `stringify` and `parse` methods compatible with Javascript's `JSON` to override the serializer used.
+
+- `sessionModelName` By default, the session table is called `sessions` and the associated model is `session`, but you can provide a custom model name. This should be the camelCase version of the name.
 
 Three new options were added apart from the work that was already done by [memorystore](https://github.com/roccomuso/memorystore), two of them relate to logging and allow you to inject your own logger object giving you flexibility to log outputs to something like NestJS or whenever you would like, even saving them to disk if that's what you want. And the third is used for testing to round the TTL so that it can be compared do another generated ttl during the assertion.
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,3 +16,10 @@ model Session {
   data    String
   expiresAt DateTime
 }
+
+model OtherSession {
+  id      String   @id
+  sid     String   @unique
+  data    String
+  expiresAt DateTime
+}

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -18,7 +18,7 @@ export type TTLFactory = (
 /**
  * PrismaSessionStore options to alter the way the store behaves
  */
-export interface IOptions {
+export interface IOptions<M extends string = 'session'> {
   /**
    * Interval, in ms, at which PrismaSessionStore will automatically remove
    * expired sessions. Disabled by default; set to something reasonable.
@@ -93,9 +93,10 @@ export interface IOptions {
 
   /**
    * "Session Table Name"
-   * defines session table name. Defaults to sessions, or
+   * defines session table name. Defaults to sessions
    */
-  sessionModelName?: string;
+  sessionModelName?: Exclude<M, `$${string}`>;
+
   /**
    * A function to generate the Prisma Record ID for a given session ID
    *

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -92,6 +92,11 @@ export interface IOptions {
   ttl?: number | TTLFactory;
 
   /**
+   * "Session Table Name"
+   * defines session table name. Defaults to sessions, or
+   */
+  sessionModelName?: string;
+  /**
    * A function to generate the Prisma Record ID for a given session ID
    *
    * Note: If undefined and dbRecordIdIsSessionId is also undefined then a random

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -43,8 +43,8 @@ interface IDeleteArgs {
   where: { sid: string };
 }
 
-export interface IPrisma {
-  session: {
+export type IPrisma = {
+  [key: string]: {
     create(args: ICreateArgs): Promise<IPrismaSession>;
     delete(args: IDeleteArgs): Promise<IPrismaSession>;
     deleteMany(args?: unknown): Promise<unknown>;
@@ -52,6 +52,7 @@ export interface IPrisma {
     findUnique(args: IFindUniqueArgs): Promise<IPrismaSession | null>;
     update(args: IUpdateArgs): Promise<IPrismaSession>;
   };
+} & {
   $connect(): Promise<void>;
   $disconnect(): Promise<void>;
-}
+};

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -43,16 +43,17 @@ interface IDeleteArgs {
   where: { sid: string };
 }
 
-export type IPrisma = {
-  [key: string]: {
+export type IPrisma<M extends string = 'session'> = Record<
+  Exclude<M, `$${string}`>,
+  {
     create(args: ICreateArgs): Promise<IPrismaSession>;
     delete(args: IDeleteArgs): Promise<IPrismaSession>;
     deleteMany(args?: unknown): Promise<unknown>;
     findMany(args?: IFindManyArgs): Promise<IPrismaSession[]>;
     findUnique(args: IFindUniqueArgs): Promise<IPrismaSession | null>;
     update(args: IUpdateArgs): Promise<IPrismaSession>;
-  };
-} & {
+  }
+> & {
   $connect(): Promise<void>;
   $disconnect(): Promise<void>;
 };

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -29,7 +29,7 @@ import { createExpiration, defer, getTTL } from './utils';
  * );
  * ```
  */
-export class PrismaSessionStore extends Store {
+export class PrismaSessionStore<M extends string = 'session'> extends Store {
   /**
    * Initialize PrismaSessionStore with the given `prisma` and (optional) `options`.
    *
@@ -54,8 +54,8 @@ export class PrismaSessionStore extends Store {
    * ```
    */
   constructor(
-    private readonly prisma: IPrisma,
-    private readonly options: IOptions
+    private readonly prisma: IPrisma<M>,
+    private readonly options: IOptions<M>
   ) {
     super();
     this.startInterval();
@@ -96,9 +96,11 @@ export class PrismaSessionStore extends Store {
 
   /**
    * @description The name of the sessions model
+   *
+   * Defaults to `session` if `sessionModelName` in options is undefined
    */
-  private readonly sessionModelName =
-    this.options.sessionModelName ?? 'session';
+  private readonly sessionModelName: Exclude<M, `$${string}`> =
+    this.options.sessionModelName ?? ('session' as Exclude<M, `$${string}`>);
 
   /**
    * Attempts to connect to Prisma, displaying a pretty error if the connection is not possible.

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -235,7 +235,6 @@ export class PrismaSessionStore extends Store {
     callback?: (err?: unknown, val?: SessionData) => void
   ) => {
     if (!(await this.validateConnection())) return callback?.();
-    console.log('THIS.sessionModelName', this.sessionModelName);
     const session = await this.prisma[this.sessionModelName]
       .findUnique({
         where: { sid },

--- a/src/lib/utils/get-ttl.ts
+++ b/src/lib/utils/get-ttl.ts
@@ -11,8 +11,8 @@ import { ONE_DAY_MS } from './constants';
  * @param session the session data
  * @param sid the id of the current session
  */
-export const getTTL = (
-  options: Pick<IOptions, 'ttl'>,
+export const getTTL = <M extends string>(
+  options: Pick<IOptions<M>, 'ttl'>,
   session: PartialDeep<SessionData>,
   sid: string
 ) => {

--- a/src/mocks/prisma.mock.ts
+++ b/src/mocks/prisma.mock.ts
@@ -9,6 +9,13 @@ export const createPrismaMock = () => {
   const findUniqueMock = jest.fn();
   const updateMock = jest.fn();
 
+  const otherCreateMock = jest.fn();
+  const otherDeleteMock = jest.fn();
+  const otherDeleteManyMock = jest.fn();
+  const otherFindManyMock = jest.fn();
+  const otherFindUniqueMock = jest.fn();
+  const otherUpdateMock = jest.fn();
+
   const prisma = {
     $connect: connectMock,
     $disconnect: disconnectMock,
@@ -19,6 +26,15 @@ export const createPrismaMock = () => {
       findMany: findManyMock,
       findUnique: findUniqueMock,
       update: updateMock,
+    },
+
+    otherSession: {
+      create: otherCreateMock,
+      delete: otherDeleteMock,
+      deleteMany: otherDeleteManyMock,
+      findMany: otherFindManyMock,
+      findUnique: otherFindUniqueMock,
+      update: otherUpdateMock,
     },
   };
 
@@ -41,6 +57,12 @@ export const createPrismaMock = () => {
       findManyMock,
       findUniqueMock,
       updateMock,
+      otherCreateMock,
+      otherDeleteMock,
+      otherDeleteManyMock,
+      otherFindManyMock,
+      otherFindUniqueMock,
+      otherUpdateMock,
     },
   ] as const;
 };

--- a/tests/integration.spec.ts
+++ b/tests/integration.spec.ts
@@ -32,6 +32,7 @@ describe('integration testing', () => {
         saveUninitialized: false,
         store: new PrismaSessionStore(prisma, {
           logger: false,
+          sessionModelName: 'otherSession',
         }),
       })
     );
@@ -62,14 +63,14 @@ describe('integration testing', () => {
   });
 
   beforeEach(async () => {
-    await prisma.session.deleteMany({});
+    await prisma.otherSession.deleteMany({});
   });
 
   it('should not initialize a user session when the session is not modified', async () => {
     await request(app)
       .get('/')
       .expect(async ({ headers }) => {
-        const sessions = await prisma.session.findMany();
+        const sessions = await prisma.otherSession.findMany();
         expect(sessions).toHaveLength(0);
         expect(headers).not.toHaveProperty('set-cookie');
       });
@@ -79,7 +80,7 @@ describe('integration testing', () => {
     await request(app)
       .post('/')
       .expect(async ({ headers }) => {
-        const sessions = await prisma.session.findMany();
+        const sessions = await prisma.otherSession.findMany();
         expect(sessions).toHaveLength(1);
         expect(headers).toHaveProperty('set-cookie');
       });
@@ -94,7 +95,7 @@ describe('integration testing', () => {
       .delete('/')
       .set('Cookie', sessionCookie)
       .expect(async () => {
-        const sessions = await prisma.session.findMany();
+        const sessions = await prisma.otherSession.findMany();
         expect(sessions).toHaveLength(0);
       });
   });
@@ -104,7 +105,7 @@ describe('integration testing', () => {
       .post('/')
       .then(async ({ headers }) => headers['set-cookie']);
 
-    const [newSession] = await prisma.session.findMany();
+    const [newSession] = await prisma.otherSession.findMany();
     expect(JSON.parse(newSession.data)).toStrictEqual(
       expect.objectContaining({
         data: 'TESTING',
@@ -113,7 +114,7 @@ describe('integration testing', () => {
 
     await request(app).put('/').set('Cookie', sessionCookie);
 
-    const [updatedSession] = await prisma.session.findMany();
+    const [updatedSession] = await prisma.otherSession.findMany();
     expect(JSON.parse(updatedSession.data)).toStrictEqual(
       expect.objectContaining({
         data: 'UPDATED',


### PR DESCRIPTION
eg usage:

```js
session({
  secret: process.env.COOKIE_SECRET || 'secret',
  store: new PrismaSessionStore(
     prisma,
     {
       sessionModelName: 'oAuthSession'
     }
   ),
  cookie: { maxAge: 7 * 24 * 60 * 60 * 1000 } // 1 week
})
```