### PR TITLE
fix(package): fix #60: move prisma to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "cuid": "^2.1.8",
-    "prisma": "^2.29.1",
     "ts-dedent": "^2.0.0",
     "type-fest": "^0.20.2"
   },
@@ -71,6 +70,7 @@
     "jest": "^26.6.3",
     "prettier": "^2.2.1",
     "pretty-quick": "^3.1.0",
+    "prisma": "^2.29.1",
     "semantic-release": "^17.3.1",
     "supertest": "^6.1.3",
     "ts-jest": "^26.5.1",


### PR DESCRIPTION
Move prisma to dev deps so that it doesn't mess with dep resolution for end-users. I know you did this in another PR but since that's held up would you mind publishing just this change so I can get unblocked?