### PR TITLE
feat: support for logging out of all sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Three new options were added apart from the work that was already done by [memor
 - `startInterval()` and `stopInterval()` methods to start/clear the automatic check for expired.
 - `prune()` that you can use to manually remove only the expired entries from the store.
 - `shutdown()` that can be used to stop any intervals and disconnect from prisma.
+- `destroyUsersSessions(sid, callback)` to destroy all sessions for user associated with `sid` (presuming sessions have been created with `data` containing a `uid` user id/name property).
 
 ## Author
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,15 +11,25 @@ generator client {
 }
 
 model Session {
-  id      String   @id
-  sid     String   @unique
+  id      String   @id //Record id
+  sid     String   @unique //Session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
+  uid     String?  //Optional user id / name
+                   // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+                   // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
+                   // * Required to delete all sessions for a given user via destroyUsersSessions().  
+                   // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
   data    String
   expiresAt DateTime
 }
 
 model OtherSession {
-  id      String   @id
-  sid     String   @unique
+  id      String   @id //Record id
+  sid     String   @unique //Session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
+  uid     String?  //Optional user id / name
+                   // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+                   // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
+                   // * Required to delete all sessions for a given user via destroyUsersSessions().  
+                   // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
   data    String
   expiresAt DateTime
 }

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -1,7 +1,7 @@
 export interface IPrismaSession {
   id: string; //record id
   sid: string; //session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
-  uid?: string | null; //Optional user id / name
+  uid?: string | null; // Optional user id / name
   // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
   // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
   // * Required to delete all sessions for a given user via destroyUsersSessions().

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -1,11 +1,16 @@
 export interface IPrismaSession {
+  id: string; //record id
+  sid: string; //session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
+  uid?: string | null; //Optional user id / name
+  // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+  // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
+  // * Required to delete all sessions for a given user via destroyUsersSessions().
+  // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
   data: string | null;
   expiresAt: Date;
-  id: string;
-  sid: string;
 }
 
-interface ICreatePrismaSession extends IPrismaSession {
+export interface ICreatePrismaSession extends IPrismaSession {
   data: string;
 }
 
@@ -27,15 +32,18 @@ interface IFindManyArgs {
   };
   where?: {
     sid?: string;
+    uid?: string;
   };
 }
 
 interface ICreateArgs {
   data: ICreatePrismaSession;
+  uid?: string | null;
 }
 
 interface IUpdateArgs {
   data: Partial<ICreatePrismaSession>;
+  uid?: string | null;
   where: { sid: string };
 }
 

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -1,6 +1,6 @@
 export interface IPrismaSession {
-  id: string; //record id
-  sid: string; //session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
+  id: string; // record id
+  sid: string; // session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
   // Optional user id / name
   // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
   // * Auto-populated by set(), if the session argument passed to set() includes a uid property.

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -1,11 +1,12 @@
 export interface IPrismaSession {
   id: string; //record id
   sid: string; //session id (which can be configured to be same as record id, using dbRecordIdIsSessionId option)
-  uid?: string | null; // Optional user id / name
+  // Optional user id / name
   // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
   // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
-  // * Required to delete all sessions for a given user via destroyUsersSessions().
+  // * Required to deletenpm install -g tslint all sessions for a given user via destroyUsersSessions().
   // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+  uid?: string | null;
   data: string | null;
   expiresAt: Date;
 }

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -11,7 +11,7 @@ declare module 'express-session' {
   interface SessionData {
     sample?: boolean;
     unrealizable?: string;
-    //Optional user id / name
+    // Optional user id / name
     // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
     // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
     // * Required to delete all sessions for a given user via destroyUsersSessions().
@@ -201,9 +201,9 @@ describe('PrismaSessionStore', () => {
     it('should delete all sessions for user associated with session sid-0 (user id: uid-0)', async () => {
       const [store, { findUniqueMock, deleteManyMock }] = freshStore();
 
-      const sid0: string = 'sid-0';
-      const uid0: string = 'uid-0';
-      const session0Data: string = `{"sample": false, "uid": "${uid0}}"}`;
+      const sid0 = 'sid-0';
+      const uid0 = 'uid-0';
+      const session0Data = `{"sample": false, "uid": "${uid0}}"}`;
 
       findUniqueMock.mockResolvedValue({
         sid: sid0,
@@ -226,7 +226,7 @@ describe('PrismaSessionStore', () => {
     it('should fail gracefully when attempting to delete non-existent item', async () => {
       const [store, { findUniqueMock }] = freshStore();
 
-      findUniqueMock.mockRejectedValue('Could not delete items'); //When attempting to delete non-existent item, fails on finding it
+      findUniqueMock.mockResolvedValue(null);
 
       const deletePromise = store.destroyUsersSessions('sid-0');
 
@@ -236,12 +236,12 @@ describe('PrismaSessionStore', () => {
     it('should delete an array of sids', async () => {
       const [store, { deleteManyMock, findUniqueMock }] = freshStore();
 
-      const sid0: string = 'sid-0';
-      const uid0: string = 'uid-0';
-      const session0Data: string = `{"sample": false, "uid": "${uid0}}"}`;
+      const sid0 = 'sid-0';
+      const uid0 = 'uid-0';
+      const session0Data = `{"sample": false, "uid": "${uid0}}"}`;
 
-      //XXX: This value should actually change, with each array value in the
-      //destroyUsersSessions([]) call below... How to accomplish this with Jest?
+      // XXX: This value should actually change, with each array value in the
+      // destroyUsersSessions([]) call below... How to accomplish this with Jest?
       findUniqueMock.mockResolvedValue({
         sid: sid0,
         uid: uid0,
@@ -250,22 +250,22 @@ describe('PrismaSessionStore', () => {
 
       await store.destroyUsersSessions(['sid-0', 'sid-1', 'sid-2']);
 
-      expect(deleteManyMock).toHaveBeenCalledTimes(1); //XXX Depending on the user ids associated with the array above, this value could change.
+      expect(deleteManyMock).toHaveBeenCalledTimes(1); // XXX Depending on the user ids associated with the array above, this value could change.
     });
 
     it('should pass errors to callback', async () => {
-      const [store, { findUniqueMock, deleteManyMock }] = freshStore();
+      const [store, { findUniqueMock }] = freshStore();
 
-      //Session provided doesn't exist
+      // Session provided doesn't exist
       const callback1 = jest.fn();
       findUniqueMock.mockRejectedValue('Session doesnt exist error');
       await store.destroyUsersSessions('sid-0', callback1);
       expect(callback1).toHaveBeenCalledWith('Session doesnt exist error');
 
-      //Session provided doesn't have an associated user id
+      // Session provided doesn't have an associated user id
       const callback2 = jest.fn();
-      const sid0: string = 'sid-0';
-      const session0Data: string = `{"sample": false}`;
+      const sid0 = 'sid-0';
+      const session0Data = `{"sample": false}`;
       findUniqueMock.mockResolvedValue({
         sid: sid0,
         data: session0Data,

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -13,6 +13,7 @@ declare module 'express-session' {
     unrealizable?: string;
     /**
      * Optional user id / name
+     *
      * - Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
      * - Auto-populated by set(), if the session argument passed to set() includes a uid property.
      * - Required to delete all sessions for a given user via destroyUsersSessions().

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -11,11 +11,12 @@ declare module 'express-session' {
   interface SessionData {
     sample?: boolean;
     unrealizable?: string;
-    uid?: string; //Optional user id / name
+    //Optional user id / name
     // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
     // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
     // * Required to delete all sessions for a given user via destroyUsersSessions().
     // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+    uid?: string;
     data?: string;
   }
 }

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -11,11 +11,13 @@ declare module 'express-session' {
   interface SessionData {
     sample?: boolean;
     unrealizable?: string;
-    // Optional user id / name
-    // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
-    // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
-    // * Required to delete all sessions for a given user via destroyUsersSessions().
-    // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+    /**
+     * Optional user id / name
+     * - Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+     * - Auto-populated by set(), if the session argument passed to set() includes a uid property.
+     * - Required to delete all sessions for a given user via destroyUsersSessions().
+     * - Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+     */
     uid?: string;
     data?: string;
   }

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -198,8 +198,10 @@ describe('PrismaSessionStore', () => {
   });
 
   describe('.destroyUsersSessions()', () => {
-    it('should delete all sessions for user associated with session sid-0 (user id: uid-0)', async () => {
+    it('should delete sessions for user associated with session sid-0 (user id: uid-0)', async () => {
       const [store, { findUniqueMock, deleteManyMock }] = freshStore();
+
+      const callback = jest.fn();
 
       const sid0 = 'sid-0';
       const uid0 = 'uid-0';
@@ -211,7 +213,7 @@ describe('PrismaSessionStore', () => {
         data: session0Data,
       });
 
-      await store.destroyUsersSessions(sid0);
+      await store.destroyUsersSessions(sid0, callback);
 
       expect(findUniqueMock).toHaveBeenCalledWith(
         expect.objectContaining({ where: { sid: sid0 } })

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -638,6 +638,7 @@ describe('PrismaSessionStore', () => {
         await invalidPrisma.set('', {});
         await invalidPrisma.touch('', {});
         await invalidPrisma.destroy('');
+        await invalidPrisma.destroyUsersSessions('');
         await invalidPrisma.all();
         await invalidPrisma.ids();
         await invalidPrisma.length();
@@ -648,6 +649,7 @@ describe('PrismaSessionStore', () => {
         await invalidPrismaKeys.set('', {});
         await invalidPrismaKeys.touch('', {});
         await invalidPrismaKeys.destroy('');
+        await invalidPrismaKeys.destroyUsersSessions('');
         await invalidPrismaKeys.all();
         await invalidPrismaKeys.ids();
         await invalidPrismaKeys.length();
@@ -659,6 +661,7 @@ describe('PrismaSessionStore', () => {
         await invalidPrisma.set('', {}, callback);
         await invalidPrisma.touch('', {}, callback);
         await invalidPrisma.destroy('', callback);
+        await invalidPrisma.destroyUsersSessions('', callback);
         await invalidPrisma.all(callback);
         await invalidPrisma.ids(callback);
         await invalidPrisma.length(callback);
@@ -668,12 +671,13 @@ describe('PrismaSessionStore', () => {
         await invalidPrismaKeys.set('', {}, callback);
         await invalidPrismaKeys.touch('', {}, callback);
         await invalidPrismaKeys.destroy('', callback);
+        await invalidPrismaKeys.destroyUsersSessions('', callback);
         await invalidPrismaKeys.all(callback);
         await invalidPrismaKeys.ids(callback);
         await invalidPrismaKeys.length(callback);
         await invalidPrismaKeys.clear(callback);
 
-        expect(callback).toHaveBeenCalledTimes(16);
+        expect(callback).toHaveBeenCalledTimes(18);
       });
     });
 

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -4,10 +4,10 @@ import { dedent } from 'ts-dedent';
 import type { PartialDeep } from 'type-fest';
 
 import type {
+  ICreatePrismaSession,
   IOptions,
   IPrisma,
   ISessions,
-  ICreatePrismaSession,
 } from '../@types';
 
 import { ManagedLogger } from './logger';
@@ -16,7 +16,7 @@ import { createExpiration, defer, getTTL } from './utils';
 declare module 'express-session' {
   // tslint:disable-next-line: naming-convention
   interface SessionData {
-    uid?: string; //Optional user id / name
+    uid?: string; // Optional user id / name
     // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
     // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
     // * Required to delete all sessions for a given user via destroyUsersSessions().
@@ -237,10 +237,13 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
       this.logger.warn(
         `Attempt to destroy non-existent session:${String(sid)} ${String(e)}`
       );
-      if (callback) return defer(callback, e);
+      if (callback) defer(callback, e);
+      return;
     }
 
-    if (callback) defer(callback);
+    if (callback) {
+      defer(callback);
+    }
   };
 
   /**
@@ -298,7 +301,8 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
           sid
         )}: ${String(e)}`
       );
-      if (callback) return defer(callback, e);
+      if (callback) defer(callback, e);
+      return;
     }
 
     if (callback) defer(callback);

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -16,11 +16,13 @@ import { createExpiration, defer, getTTL } from './utils';
 declare module 'express-session' {
   // tslint:disable-next-line: naming-convention
   interface SessionData {
-    // Optional user id / name
-    // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
-    // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
-    // * Required to delete all sessions for a given user via destroyUsersSessions().
-    // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+    /**
+     * Optional user id / name
+     * - Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+     * - Auto-populated by set(), if the session argument passed to set() includes a uid property.
+     * - Required to delete all sessions for a given user via destroyUsersSessions().
+     * - Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+     */
     uid?: string;
     data?: string;
   }

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -281,7 +281,7 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
           throw Error(errMsg);
         }
         const uid = s.uid;
-        if (typeof uid !== 'string') {
+        if (typeof uid !== 'string' || uid === '') {
           const errMsg = `No user id found for provided session id: ${String(
             sid
           )}`;

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -13,6 +13,20 @@ import type {
 import { ManagedLogger } from './logger';
 import { createExpiration, defer, getTTL } from './utils';
 
+declare module 'express-session' {
+  // tslint:disable-next-line: naming-convention
+  interface SessionData {
+    sample?: boolean;
+    unrealizable?: string;
+    uid?: string; //Optional user id / name
+    // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
+    // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
+    // * Required to delete all sessions for a given user via destroyUsersSessions().
+    // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+    data?: string;
+  }
+}
+
 /**
  * An `express-session` store used in the `express-session` options
  * to hook up prisma as a session store

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -456,15 +456,13 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
     }
 
     if (existingSession !== null) {
-      const updateData: Partial<ICreatePrismaSession> = baseData;
       await this.prisma[this.sessionModelName].update({
-        data: updateData,
+        data: baseData,
         where: { sid },
       });
     } else {
-      const createData: ICreatePrismaSession = { ...baseData };
       await this.prisma[this.sessionModelName].create({
-        data: { ...createData, data: sessionString },
+        data: { ...baseData, data: sessionString },
       });
     }
 

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -464,13 +464,13 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
       })
       .catch(() => null);
 
-    let data: ICreatePrismaSession = {
+    const data: ICreatePrismaSession = {
+      ...(uid ? { uid } : {}),
       sid,
       expiresAt,
       data: sessionString,
       id: this.dbRecordIdIsSessionId ? sid : this.dbRecordIdFunction(sid),
     };
-    if (uid) data = { ...data, uid };
 
     if (existingSession !== null) {
       await this.prisma[this.sessionModelName].update({

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -16,11 +16,12 @@ import { createExpiration, defer, getTTL } from './utils';
 declare module 'express-session' {
   // tslint:disable-next-line: naming-convention
   interface SessionData {
-    uid?: string; // Optional user id / name
+    // Optional user id / name
     // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
     // * Auto-populated by set(), if the session argument passed to set() includes a uid property.
     // * Required to delete all sessions for a given user via destroyUsersSessions().
     // * Enables functions within this package, such as destroyUsersSessions(), to make user-based queries.
+    uid?: string;
     data?: string;
   }
 }

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -16,8 +16,6 @@ import { createExpiration, defer, getTTL } from './utils';
 declare module 'express-session' {
   // tslint:disable-next-line: naming-convention
   interface SessionData {
-    sample?: boolean;
-    unrealizable?: string;
     uid?: string; //Optional user id / name
     // * Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
     // * Auto-populated by set(), if the session argument passed to set() includes a uid property.

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -18,6 +18,7 @@ declare module 'express-session' {
   interface SessionData {
     /**
      * Optional user id / name
+     *
      * - Non-unique; a given user may have multiple sessions - for multiple browsers, devices, etc.
      * - Auto-populated by set(), if the session argument passed to set() includes a uid property.
      * - Required to delete all sessions for a given user via destroyUsersSessions().


### PR DESCRIPTION
Adds a function, `destroyUsersSessions()`, to enable deleting _all sessions for a given user_, given the session id for _one_ of the given user's sessions.

Note: Use of this functionality requires that all sessions have been added to the store using the store's `set()` function with the set() function's `session` argument containing a (new) `uid` (user id / user name) property.

Question: This feature necessitate addition of a new `uid` (user id / name) field to `schema.prisma`. Could this create any backward-compatability issues? Can/should they be mitigated by this library?