### PR TITLE
Address interval-related errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Three new options were added apart from the work that was already done by [memor
 
 `prisma-session-store` implements all the **required**, **recommended** and **optional** methods of the [express-session](https://github.com/expressjs/session#session-store-implementation) store, plus a few more:
 
-- `startInterval(onIntervalError?: (err: unknown) => void)` and `stopInterval()` methods to start/clear the automatic check for expired. (The optional onError() callback that fires if ever the interval function throws an error.)
+- `startInterval(onIntervalError?: (err: unknown) => void)` and `stopInterval()` methods to start/clear the automatic check for expired. (The optional `onError()` callback that fires if/when the interval's `prune()` function throws an error.)
 - `prune()` that you can use to manually remove only the expired entries from the store.
 - `shutdown()` that can be used to stop any intervals and disconnect from prisma.
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ Three new options were added apart from the work that was already done by [memor
 
 `prisma-session-store` implements all the **required**, **recommended** and **optional** methods of the [express-session](https://github.com/expressjs/session#session-store-implementation) store, plus a few more:
 
-- `startInterval()` and `stopInterval()` methods to start/clear the automatic check for expired.
+- `startInterval(onIntervalError?: (err: unknown) => void)` and `stopInterval()` methods to start/clear the automatic check for expired. (The optional onError() callback that fires if ever the interval function throws an error.)
 - `prune()` that you can use to manually remove only the expired entries from the store.
 - `shutdown()` that can be used to stop any intervals and disconnect from prisma.
 

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -418,13 +418,16 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
   /**
    * Start an interval to prune expired sessions
    */
-  public startInterval(): void {
+  public startInterval(onIntervalError?: (err: unknown) => void): void {
     const ms = this.options.checkPeriod;
-
     if (typeof ms === 'number' && ms !== 0) {
       this.stopInterval();
-      this.checkInterval = setInterval(() => {
-        this.prune();
+      this.checkInterval = setInterval(async () => {
+        try {
+          await this.prune();
+        } catch (err: unknown) {
+          if (onIntervalError !== undefined) onIntervalError(err);
+        }
       }, Math.floor(ms));
     }
   }


### PR DESCRIPTION
This PR addresses interval-related errors; preventing crashes, while allowing errors to surface.
* Moves `setInterval()`'s `prune()` invocation to inside a try/catch block
* Adds an optional `onIntervalError(error)` callback argument to `setInterval()`, to enable surfacing errors 