### PR TITLE
fix: remove immutable id field from query for MongoDB

### DIFF
--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -279,7 +279,6 @@ describe('PrismaSessionStore', () => {
       expect(updateMock).toHaveBeenCalledWith({
         data: expect.objectContaining({
           data: '{"cookie":{},"sample":true}',
-          id: 'sid-0',
           sid: 'sid-0',
         }),
         where: {

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -388,7 +388,6 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
       sid,
       expiresAt,
       data: sessionString,
-      id: this.dbRecordIdIsSessionId ? sid : this.dbRecordIdFunction(sid),
     };
 
     try {
@@ -399,7 +398,11 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
         });
       } else {
         await this.prisma[this.sessionModelName].create({
-          data: { ...data, data: sessionString },
+          data: {
+            ...data,
+            id: this.dbRecordIdIsSessionId ? sid : this.dbRecordIdFunction(sid),
+            data: sessionString,
+          },
         });
       }
     } catch (e: unknown) {


### PR DESCRIPTION
This fixes issue #83 and should provide proper MongoDB support.