### PR TITLE
Allow prisma.schema to use Json data type for session data

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ From your **prisma.schema** file, include a session model:
 model Session {
   id        String   @id
   sid       String   @unique
-  data      String
+  data      Json     @db.Json
   expiresAt   DateTime
 }
 ```


### PR DESCRIPTION
Increases flexibility of storing type safe data from auth serialization