### PR TITLE
fix: replace cuid with cuid2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=12.0"
   },
   "dependencies": {
-    "cuid": "^2.1.8",
+    "@paralleldrive/cuid2": "^2.2.0",
     "ts-dedent": "^2.2.0",
     "type-fest": "^2.5.2"
   },
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@commitlint/cli": "^13.2.1",
     "@commitlint/config-conventional": "^13.2.0",
-    "prisma": "^3.3.0",
     "@prisma/client": "^3.3.0",
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
@@ -71,6 +70,7 @@
     "jest": "^27.3.1",
     "prettier": "^2.4.1",
     "pretty-quick": "^3.1.1",
+    "prisma": "^3.3.0",
     "semantic-release": "^19.0.3",
     "supertest": "^6.1.6",
     "ts-jest": "^27.0.7",

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -1,4 +1,4 @@
-import cuid from 'cuid';
+import cuid2 from '@paralleldrive/cuid2';
 import { SessionData, Store } from 'express-session';
 import { dedent } from 'ts-dedent';
 import type { PartialDeep } from 'type-fest';
@@ -145,7 +145,7 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
    * CUID will be used instead.
    */
   private readonly dbRecordIdFunction = (sid: string) =>
-    this.options.dbRecordIdFunction?.(sid) ?? cuid();
+    this.options.dbRecordIdFunction?.(sid) ?? cuid2.createId();
 
   /**
    * Disables store, used when prisma cannot be connected to

--- a/yarn.lock
+++ b/yarn.lock
@@ -765,6 +765,11 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@noble/hashes@^1.1.5":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
+  integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1057,6 +1062,13 @@
   integrity sha512-aHm+olfIZjQpzoODpl+RCZzchKOrdSLJs+yfI7pMMcmB19Li6vidgx0DwUDO/Ic4Q3fq/lOjJORVCcLZefcrJw==
   dependencies:
     "@octokit/openapi-types" "^13.11.0"
+
+"@paralleldrive/cuid2@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@paralleldrive/cuid2/-/cuid2-2.2.0.tgz#105b31311994c18d816cb0d31f31ecaf425d32b4"
+  integrity sha512-CVQDpPIUHrUGGLdrMGz1NmqZvqmsB2j2rCIQEu1EvxWjlFh4fhvEGmgR409cY20/67/WlJsggenq0no3p3kYsw==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
 
 "@phenomnomnominal/tsquery@^4.0.0":
   version "4.2.0"
@@ -2354,11 +2366,6 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
-
-cuid@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.8.tgz#cbb88f954171e0d5747606c0139fb65c5101eac0"
-  integrity sha512-xiEMER6E7TlTPnDxrM4eRiC6TRgjNX9xzEZ5U/Se2YJKr7Mq4pJn/2XEHjl3STcSh96GmkHPcBXLES8M29wyyg==
 
 cz-conventional-changelog@3.3.0:
   version "3.3.0"


### PR DESCRIPTION
Following the security recommendation of cuid package developers:

https://github.com/paralleldrive/cuid#status-deprecated-due-to-security-use-cuid2-instead 

and NPM deprecated warning:

`npm WARN deprecated cuid@2.1.8: Cuid and other k-sortable and non-cryptographic ids (Ulid, ObjectId, KSUID, all UUIDs) are all insecure. Use @paralleldrive/cuid2 instead.`

`cuid` must be replaced with `@paralleldrive/cuid2` due to collision risk in `cuid`.