### PR TITLE
Update README.md guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ From your **prisma.schema** file, include a session model:
 model Session {
   id        String   @id
   sid       String   @unique
-  data      String   @db.MediumText
+  data      String   @db.MediumText  // MediumText may be needed for MySql
   expiresAt   DateTime
 }
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ From your **prisma.schema** file, include a session model:
 model Session {
   id        String   @id
   sid       String   @unique
-  data      String
+  data      String   @db.MediumText
   expiresAt   DateTime
 }
 ```


### PR DESCRIPTION
I was getting this error because of using the settings from the readme file.
```bash
PrismaClientKnownRequestError:
Invalid `this.prisma[this.sessionModelName].create()` invocation in
D:\Coding Files\admin-server\node_modules\@quixo3\prisma-session-store\dist\lib\prisma-session-store.js:543:85

  540 case 4:
  541     _a.sent();
  542     return [3 /*break*/, 7];
→ 543 case 5: return [4 /*yield*/, this.prisma[this.sessionModelName].create(
The provided value for the column is too long for the column's type. Column: for
    at Rn.handleRequestError (D:\Coding Files\admin-server\node_modules\@prisma\client\runtime\library.js:174:7325)
    at Rn.handleAndLogRequestError (D:\Coding Files\admin-server\node_modules\@prisma\client\runtime\library.js:174:6754)
    at Rn.request (D:\Coding Files\admin-server\node_modules\@prisma\client\runtime\library.js:174:6344)
```

After doing some research I had to change update this settings on my prisma schema.

Updating this hoping it would be beneficial for someone.

```diff
- data      String
+ data      String   @db.MediumText
```
