### PR TITLE
fix(mysql): add native upsert strategy for session set

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ Five new options were added, apart from the work that was already done by [memor
 
 - `enableConcurrentSetInvocationsForSameSessionID` and `enableConcurrentTouchInvocationsForSameSessionID`. Since v3.1.9, concurrent calls to set() and touch() for the same session id have been disabled, as a work-around for an issue that users have been experiencing (see [Issue 88](https://github.com/kleydon/prisma-session-store/issues/88)). This issue may occur when a browser is loading multiple resources for a page in parallel. The issue may be limited to use of SQLite, but has not yet been isolated; `express-session` or `prisma` may be implicated. If necessary, you can prevent this default behavior and re-enable concurrent calls having the same session id by setting one or both of these variables to `true`.
 
+- `enableNativeMysqlSetUpsert`. Disabled by default. When set to `true`, `set()` uses a MySQL / MariaDB native atomic write based on `INSERT ... ON DUPLICATE KEY UPDATE`. This can avoid primary-key race failures caused by concurrent `set()` calls for the same session id. This option is MySQL / MariaDB specific and should not be enabled for other database engines.
+
 ## Methods
 
 `prisma-session-store` implements all the **required**, **recommended** and **optional** methods of the [express-session](https://github.com/expressjs/session#session-store-implementation) store, plus a few more:

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -124,6 +124,19 @@ export interface IOptions<M extends string = 'session'> {
   enableConcurrentTouchInvocationsForSameSessionID?: boolean;
 
   /**
+   * enableNativeMysqlSetUpsert: boolean;
+   *
+   * Enables an atomic MySQL / MariaDB write path for set() using:
+   *   INSERT ... ON DUPLICATE KEY UPDATE
+   *
+   * This avoids the read-then-create race that can occur when multiple
+   * concurrent set() calls use the same session ID.
+   *
+   * Disabled by default because this strategy is MySQL / MariaDB specific.
+   */
+  enableNativeMysqlSetUpsert?: boolean;
+
+  /**
    * A function to generate the Prisma Record ID for a given session ID
    *
    * Note: If undefined and dbRecordIdIsSessionId is also undefined then a random

--- a/src/@types/prisma.ts
+++ b/src/@types/prisma.ts
@@ -56,4 +56,5 @@ export type IPrisma<M extends string = 'session'> = Record<
 > & {
   $connect(): Promise<void>;
   $disconnect(): Promise<void>;
+  $executeRawUnsafe?(query: string, ...values: unknown[]): Promise<unknown>;
 };

--- a/src/lib/prisma-session-store.spec.ts
+++ b/src/lib/prisma-session-store.spec.ts
@@ -358,6 +358,47 @@ describe('PrismaSessionStore', () => {
       });
     });
 
+    it('should use native MySQL upsert when enableNativeMysqlSetUpsert is true', async () => {
+      const [
+        store,
+        { executeRawUnsafeMock, findUniqueMock, createMock, updateMock },
+      ] = freshStore({
+        enableNativeMysqlSetUpsert: true,
+      });
+
+      await store.set('sid-0', { cookie: { maxAge: 300 }, sample: true });
+
+      expect(executeRawUnsafeMock).toHaveBeenCalledWith(
+        'INSERT INTO `Session` (`id`, `sid`, `expiresAt`, `data`) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE `sid` = VALUES(`sid`), `expiresAt` = VALUES(`expiresAt`), `data` = VALUES(`data`)',
+        'sid-0',
+        'sid-0',
+        expect.any(Date),
+        '{"cookie":{"maxAge":300},"sample":true}'
+      );
+      expect(findUniqueMock).not.toHaveBeenCalled();
+      expect(createMock).not.toHaveBeenCalled();
+      expect(updateMock).not.toHaveBeenCalled();
+    });
+
+    it('should send a clear error when native MySQL upsert is enabled without raw execution support', async () => {
+      const [store] = freshStore({
+        enableNativeMysqlSetUpsert: true,
+      });
+      const callback = jest.fn();
+
+      delete (store as unknown as { prisma: { $executeRawUnsafe?: unknown } })
+        .prisma.$executeRawUnsafe;
+
+      await store.set('sid-0', { data: 'a' }, callback);
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            'enableNativeMysqlSetUpsert requires a Prisma client exposing $executeRawUnsafe.',
+        })
+      );
+    });
+
     it('should should not reject when errors occur', async () => {
       const stringify = jest.fn();
       const [store] = freshStore({

--- a/src/lib/prisma-session-store.ts
+++ b/src/lib/prisma-session-store.ts
@@ -477,32 +477,50 @@ export class PrismaSessionStore<M extends string = 'session'> extends Store {
       return;
     }
 
-    const existingSession = await this.prisma[this.sessionModelName]
-      .findUnique({
-        where: { sid },
-      })
-      .catch(() => null);
-
     const data = {
       sid,
       expiresAt,
       data: sessionString,
     };
 
+    const id = this.dbRecordIdIsSessionId ? sid : this.dbRecordIdFunction(sid);
+
     try {
-      if (existingSession !== null) {
-        await this.prisma[this.sessionModelName].update({
-          data,
-          where: { sid },
-        });
+      if (this.options.enableNativeMysqlSetUpsert === true) {
+        if (typeof this.prisma.$executeRawUnsafe !== 'function') {
+          throw new Error(
+            'enableNativeMysqlSetUpsert requires a Prisma client exposing $executeRawUnsafe.'
+          );
+        }
+
+        await this.prisma.$executeRawUnsafe(
+          'INSERT INTO `Session` (`id`, `sid`, `expiresAt`, `data`) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE `sid` = VALUES(`sid`), `expiresAt` = VALUES(`expiresAt`), `data` = VALUES(`data`)',
+          id,
+          sid,
+          expiresAt,
+          sessionString
+        );
       } else {
-        await this.prisma[this.sessionModelName].create({
-          data: {
-            ...data,
-            id: this.dbRecordIdIsSessionId ? sid : this.dbRecordIdFunction(sid),
-            data: sessionString,
-          },
-        });
+        const existingSession = await this.prisma[this.sessionModelName]
+          .findUnique({
+            where: { sid },
+          })
+          .catch(() => null);
+
+        if (existingSession !== null) {
+          await this.prisma[this.sessionModelName].update({
+            data,
+            where: { sid },
+          });
+        } else {
+          await this.prisma[this.sessionModelName].create({
+            data: {
+              ...data,
+              id,
+              data: sessionString,
+            },
+          });
+        }
       }
     } catch (e: unknown) {
       this.logger.error(`set(): ${String(e)}`);

--- a/src/mocks/prisma.mock.ts
+++ b/src/mocks/prisma.mock.ts
@@ -1,6 +1,7 @@
 export const createPrismaMock = () => {
   const connectMock = jest.fn();
   const disconnectMock = jest.fn();
+  const executeRawUnsafeMock = jest.fn();
 
   const createMock = jest.fn();
   const deleteMock = jest.fn();
@@ -19,6 +20,7 @@ export const createPrismaMock = () => {
   const prisma = {
     $connect: connectMock,
     $disconnect: disconnectMock,
+    $executeRawUnsafe: executeRawUnsafeMock,
     session: {
       create: createMock,
       delete: deleteMock,
@@ -40,6 +42,7 @@ export const createPrismaMock = () => {
 
   connectMock.mockResolvedValue(undefined);
   disconnectMock.mockResolvedValue(undefined);
+  executeRawUnsafeMock.mockResolvedValue(undefined);
   findUniqueMock.mockResolvedValue(null);
   findManyMock.mockResolvedValue([]);
   deleteManyMock.mockResolvedValue([]);
@@ -51,6 +54,7 @@ export const createPrismaMock = () => {
     {
       connectMock,
       disconnectMock,
+      executeRawUnsafeMock,
       createMock,
       deleteMock,
       deleteManyMock,


### PR DESCRIPTION
Adds an opt-in MySQL / MariaDB write strategy for set() using INSERT ... ON DUPLICATE KEY UPDATE.

Why:
Concurrent set() calls for the same sid can still hit PRIMARY unique constraint failures when the default read-then-create flow is used. This was reproduced with high-concurrency set() smoke tests.

What changed:
- Adds enableNativeMysqlSetUpsert option, disabled by default.
- Uses native MySQL / MariaDB atomic upsert when the option is enabled.
- Keeps existing behavior unchanged by default.
- Adds typing for $executeRawUnsafe.
- Adds unit coverage for the native upsert branch and missing raw execution support.
- Documents the new option in README.

Validation:
- npm run build
- npm run lint
- npx jest src/lib/prisma-session-store.spec.ts --coverage=false
- npx prisma generate
- npm test

Observed external smoke test:
- 500 concurrent store.set() calls: 500 fulfilled, 0 rejected
- 1000 concurrent store.set() calls: 1000 fulfilled, 0 rejected