### PR TITLE
chore: sync package version to 3.1.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@quixo3/prisma-session-store",
-  "version": "3.1.19",
+  "version": "3.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@quixo3/prisma-session-store",
-      "version": "3.1.19",
+      "version": "3.1.20",
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "PASETO",
     "JWT"
   ],
-  "version": "3.1.19",
+  "version": "3.1.20",
   "license": "MIT",
   "author": "Krispin Leydon",
   "contributors": [


### PR DESCRIPTION
Syncs package metadata with the existing GitHub release tag v3.1.20.

The GitHub release v3.1.20 points to the merge commit for #197, but package.json on master still declares 3.1.19.

Validation:
- npm run lint
- npm run build
- npx prisma generate
- npm test